### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,7 @@ jobs:
 
   deploy:
     needs: build-push
+    permissions: {}
     runs-on: ubuntu-latest
     steps:
       - name: Deploy over SSH


### PR DESCRIPTION
Potential fix for [https://github.com/stoffer123/MetarTaf/security/code-scanning/1](https://github.com/stoffer123/MetarTaf/security/code-scanning/1)

To fix the problem, we should explicitly set the `permissions` block for the `deploy` job to `{}`. This will ensure that the GITHUB_TOKEN is not available in the job, adhering to the principle of least privilege. The change should be made by adding a `permissions: {}` line under the `deploy` job definition (i.e., after `needs: build-push` and before `runs-on: ubuntu-latest`). No other changes are required, as the job does not need any GitHub token permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
