### PR TITLE
Add Domain project and core contracts (#100)

### DIFF
--- a/Domain/Domain.csproj
+++ b/Domain/Domain.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Domain/Entities/Airport.cs
+++ b/Domain/Entities/Airport.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Domain.Entities
+{
+    public sealed class Airport
+    {
+        public string Icao { get; }
+        public string? Name { get; }
+        public string? Country { get; }
+
+        public Airport(string icao, string? name = null, string? country = null)
+        {
+            if (string.IsNullOrWhiteSpace(icao) || icao.Length != 4)
+                throw new ArgumentException("ICAO must be 4 letters", nameof(icao));
+
+            Icao = icao.ToUpperInvariant();
+            Name = name;
+            Country = country;
+        }
+    }
+}

--- a/Domain/Entities/OpmetReport.cs
+++ b/Domain/Entities/OpmetReport.cs
@@ -1,0 +1,31 @@
+﻿using Domain.ValueObjects;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Domain.Entities
+{
+    /// <summary>Samlet domænemodel for en OPMET linje (METAR/SPECI/TAF, inkl. COR/AMD).</summary>
+    public sealed class OpmetReport
+    {
+        public string Icao { get; }
+        public ReportKind Kind { get; }
+        public ReportModifier Modifier { get; }
+        public DateTime IssuedAtUtc { get; }   // “report time”
+        public DateTime FetchedAtUtc { get; }  // når vi hentede den
+        public string RawText { get; }         // hele rå linjen, som vist til bruger
+
+        public OpmetReport(string icao, ReportKind kind, ReportModifier modifier,
+                           DateTime issuedAtUtc, DateTime fetchedAtUtc, string rawText)
+        {
+            Icao = icao.ToUpperInvariant();
+            Kind = kind;
+            Modifier = modifier;
+            IssuedAtUtc = DateTime.SpecifyKind(issuedAtUtc, DateTimeKind.Utc);
+            FetchedAtUtc = DateTime.SpecifyKind(fetchedAtUtc, DateTimeKind.Utc);
+            RawText = rawText ?? "";
+        }
+    }
+}

--- a/Domain/Ports/IAirportRepository.cs
+++ b/Domain/Ports/IAirportRepository.cs
@@ -1,0 +1,15 @@
+﻿using Domain.Entities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Domain.Ports
+{
+    public interface IAirportRepository
+    {
+        Task<Airport?> GetAsync(string icao, CancellationToken ct = default);
+        Task UpsertAsync(Airport airport, CancellationToken ct = default);
+    }
+}

--- a/Domain/Ports/IOpmetFetcher.cs
+++ b/Domain/Ports/IOpmetFetcher.cs
@@ -1,0 +1,25 @@
+﻿using Domain.Entities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Domain.Ports
+{
+    /// <summary>
+    /// Port for at hente seneste OPMET pr. ICAO. Adapter i Infrastructure implementerer denne.
+    /// </summary>
+    public interface IOpmetFetcher
+    {
+        /// <returns>
+        /// Tuple af (metarMap, tafMap) hvor værdi er komplette rå linjer,
+        /// eller – alternativt – returnér allerede mappet til OpmetReport (se nedenfor).
+        /// </returns>
+        Task<(Dictionary<string, string> Metar, Dictionary<string, string> Taf)>
+            GetLatestPerIcaoRawAsync(IEnumerable<string> icaos, int windValidTime = 0, CancellationToken ct = default);
+
+        /// <summary>Valgfrit: en port der returnerer domæneobjekter direkte.</summary>
+        Task<IReadOnlyList<OpmetReport>> GetLatestPerIcaoAsync(IEnumerable<string> icaos, int windValidTime = 0, CancellationToken ct = default);
+    }
+}

--- a/Domain/Program.cs
+++ b/Domain/Program.cs
@@ -1,0 +1,2 @@
+﻿// See https://aka.ms/new-console-template for more information
+Console.WriteLine("Hello, World!");

--- a/Domain/Services/TimeService.cs
+++ b/Domain/Services/TimeService.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Domain.Services
+{
+    public static class TimeService
+    {
+        public static string FormatSignedHm(TimeSpan ts)
+        {
+            var sign = ts < TimeSpan.Zero ? "-" : "";
+            var d = ts.Duration();
+            var hours = (int)Math.Floor(d.TotalHours);
+            var minutes = d.Minutes;
+            return $"{sign}{hours:D2}:{minutes:D2}";
+        }
+    }
+}

--- a/Domain/ValueObjects/ReportType.cs
+++ b/Domain/ValueObjects/ReportType.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Domain.ValueObjects
+{
+    public enum ReportKind { Metar, Taf }
+    public enum ReportModifier { None, AMD, COR, SPECI } // SPECI som modifier til METAR
+}

--- a/MetarTaf.sln
+++ b/MetarTaf.sln
@@ -12,6 +12,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MetarTaf_Backend", "MetarTa
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MetarTaf_Tests", "MetarTaf_Tests\MetarTaf_Tests.csproj", "{1B6B0484-AA1B-4869-B66B-EE183AA0D1CC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Domain", "Domain\Domain.csproj", "{672A38AA-AD0E-49F1-A907-695C4C2C008B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,6 +32,10 @@ Global
 		{1B6B0484-AA1B-4869-B66B-EE183AA0D1CC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1B6B0484-AA1B-4869-B66B-EE183AA0D1CC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1B6B0484-AA1B-4869-B66B-EE183AA0D1CC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{672A38AA-AD0E-49F1-A907-695C4C2C008B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{672A38AA-AD0E-49F1-A907-695C4C2C008B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{672A38AA-AD0E-49F1-A907-695C4C2C008B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{672A38AA-AD0E-49F1-A907-695C4C2C008B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Closes #100

### Changes
- Added new project `MetarTaf.Domain`
- Added entities: `Airport`, `OpmetReport`
- Added value objects: `ReportKind`, `ReportModifier`
- Added ports: `IOpmetFetcher`, `IAirportRepository`
- Added service: `TimeService`

### Acceptance Criteria
- [x] Domain builds standalone
- [x] Ports are defined in Domain
- [x] No external references